### PR TITLE
Cedar 14

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,11 @@ set -e
 unset GIT_DIR
 
 # config
-STUNNEL_VERSION="4.56"
+if [ "$STACK" == "cedar-14" ]; then
+  STUNNEL_VERSION="5.08"
+else
+  STUNNEL_VERSION="5.02"
+fi
 S3_BUCKET="gregburek-buildpack-pgbouncer"
 
 # parse and derive params

--- a/bin/compile
+++ b/bin/compile
@@ -27,6 +27,7 @@ LP_DIR=`cd $(dirname $0); cd ..; pwd`
 source $LP_DIR/support/package
 
 echo "Using stunnel version: ${STUNNEL_VERSION}" | indent
+echo "Using stack version: ${STACK}" | indent
 
 # vendor directories
 VENDORED_STUNNEL="vendor/stunnel"
@@ -35,7 +36,7 @@ VENDORED_STUNNEL="vendor/stunnel"
 PATH="$BUILD_DIR/$VENDORED_STUNNEL/bin:$PATH"
 echo "-----> Fetching and vendoring stunnel into slug"
 mkdir -p "$BUILD_DIR/$VENDORED_STUNNEL/var/run/stunnel/"
-package_download "stunnel" "${STUNNEL_VERSION}" "${BUILD_DIR}/${VENDORED_STUNNEL}"
+package_download "stunnel" "${STUNNEL_VERSION}" "${BUILD_DIR}/${VENDORED_STUNNEL}" "${STACK}"
 
 
 echo "-----> Skipping the startup script"

--- a/support/package
+++ b/support/package
@@ -15,8 +15,9 @@ function package_download() {
   engine="$1"
   version="$2"
   location="$3"
+  stack="$4"
 
   mkdir -p $location
-  package="https://${S3_BUCKET}.s3.amazonaws.com/$engine-$version.tgz"
+  package="https://${S3_BUCKET}.s3.amazonaws.com/$stack/$engine-$version.tgz"
   curl $package -s -o - | tar xzf - -C $location
 }


### PR DESCRIPTION
Update the tools to get newer versions of stunnel, and use the newer OpenSSL on cedar-14 instances.
